### PR TITLE
メモを入力した場合個別リスト画面で表示できる様にする #62

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "picklist",
     "slug": "picklist",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",

--- a/app/(products)/add-to-list.tsx
+++ b/app/(products)/add-to-list.tsx
@@ -149,12 +149,16 @@ export default function AddToListScreen() {
             />
           </Pressable>
           {pickerVisible && (
-            <View style={styles.pickerModalOverlay}>
-              <View
+            <Pressable
+              style={styles.pickerModalOverlay}
+              onPress={() => setPickerVisible(false)}
+            >
+              <Pressable
                 style={[
                   styles.pickerModal,
                   { backgroundColor: colors.background.primary },
                 ]}
+                onPress={(e) => e.stopPropagation()}
               >
                 <Picker
                   selectedValue={selectedList ?? ''}
@@ -193,8 +197,8 @@ export default function AddToListScreen() {
                     閉じる
                   </Text>
                 </Pressable>
-              </View>
-            </View>
+              </Pressable>
+            </Pressable>
           )}
         </View>
 

--- a/app/(tabs)/frequent-products.tsx
+++ b/app/(tabs)/frequent-products.tsx
@@ -191,6 +191,20 @@ const ProductItem: React.FC<ProductItemProps> = ({
           </Text>
         </View>
       </View>
+      <Pressable
+        style={[
+          styles.editButton,
+          { backgroundColor: colors.background.tertiary, borderRadius: 16 },
+        ]}
+        onPress={() => router.push(`/(products)/edit?id=${item.id}`)}
+        accessibilityLabel="編集"
+      >
+        <Ionicons
+          name="create-outline"
+          size={22}
+          color={colors.accent.primary}
+        />
+      </Pressable>
     </Pressable>
   );
 };
@@ -768,5 +782,11 @@ const styles = StyleSheet.create({
   footerDescription: {
     fontSize: 15,
     color: '#aaa',
+  },
+  editButton: {
+    padding: 8,
+    marginLeft: 8,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
 });

--- a/app/(tabs)/list/[id].tsx
+++ b/app/(tabs)/list/[id].tsx
@@ -297,7 +297,10 @@ export default function ListDetailScreen() {
           />
         </View>
 
-        <ScrollView style={styles.listContent}>
+        <ScrollView
+          style={styles.listContent}
+          contentContainerStyle={{ paddingBottom: 96 }}
+        >
           <GroupedPicklistItems
             listId={id}
             onItemPress={(item) => handleToggleComplete(item.id)}

--- a/app/(tabs)/list/[id].tsx
+++ b/app/(tabs)/list/[id].tsx
@@ -34,6 +34,7 @@ export default function ListDetailScreen() {
   } | null>(null);
   const quickAddInputRef = React.useRef<TextInput>(null);
   const [menuVisible, setMenuVisible] = useState(false);
+  const [noteModalItem, setNoteModalItem] = useState<PicklistItem | null>(null);
 
   const {
     picklists,
@@ -301,6 +302,7 @@ export default function ListDetailScreen() {
             listId={id}
             onItemPress={(item) => handleToggleComplete(item.id)}
             onItemDelete={handleRemoveItem}
+            onNotePress={(item) => setNoteModalItem(item)}
           />
         </ScrollView>
 
@@ -477,6 +479,41 @@ export default function ListDetailScreen() {
                   <Text style={styles.modalDeleteButtonText}>削除</Text>
                 </Pressable>
               </View>
+            </View>
+          </View>
+        )}
+
+        {noteModalItem && (
+          <View style={styles.modalOverlay}>
+            <View
+              style={[
+                styles.modalContent,
+                { backgroundColor: colors.background.primary },
+              ]}
+            >
+              <Text style={[styles.modalTitle, { color: colors.text.primary }]}>
+                メモ
+              </Text>
+              <Text style={{ color: colors.text.primary, marginBottom: 24 }}>
+                {noteModalItem.note}
+              </Text>
+              <Pressable
+                style={[
+                  styles.modalButton,
+                  styles.modalCancelButton,
+                  { backgroundColor: isDark ? '#333' : '#f0f0f0' },
+                ]}
+                onPress={() => setNoteModalItem(null)}
+              >
+                <Text
+                  style={[
+                    styles.modalCancelButtonText,
+                    { color: colors.text.primary },
+                  ]}
+                >
+                  閉じる
+                </Text>
+              </Pressable>
             </View>
           </View>
         )}

--- a/app/(tabs)/list/[id].tsx
+++ b/app/(tabs)/list/[id].tsx
@@ -497,9 +497,11 @@ export default function ListDetailScreen() {
               <Text style={[styles.modalTitle, { color: colors.text.primary }]}>
                 メモ
               </Text>
-              <Text style={{ color: colors.text.primary, marginBottom: 24 }}>
-                {noteModalItem.note}
-              </Text>
+              <ScrollView style={{ maxHeight: 200, marginBottom: 24 }}>
+                <Text style={{ color: colors.text.primary }}>
+                  {noteModalItem.note || 'メモがありません'}
+                </Text>
+              </ScrollView>
               <Pressable
                 style={[
                   styles.modalButton,

--- a/app/(tabs)/list/[id].tsx
+++ b/app/(tabs)/list/[id].tsx
@@ -716,7 +716,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
     left: 16,
     right: 16,
-    bottom: 16,
+    bottom: 8,
     height: 48,
     borderRadius: 12,
     flexDirection: 'row',

--- a/src/components/GroupedPicklistItems.tsx
+++ b/src/components/GroupedPicklistItems.tsx
@@ -19,6 +19,7 @@ interface GroupedPicklistItemsProps {
   listId: string;
   onItemPress?: (item: PicklistItem) => void;
   onItemDelete?: (item: PicklistItem) => void;
+  onNotePress?: (item: PicklistItem) => void;
 }
 
 type ItemGroup = {
@@ -30,6 +31,7 @@ export const GroupedPicklistItems: React.FC<GroupedPicklistItemsProps> = ({
   listId,
   onItemPress,
   onItemDelete,
+  onNotePress,
 }) => {
   const { colors } = useTheme();
   const { picklists } = usePicklistStore();
@@ -161,6 +163,23 @@ export const GroupedPicklistItems: React.FC<GroupedPicklistItemsProps> = ({
             </Pressable>
           )}
         </View>
+
+        {item.note && onNotePress && (
+          <Pressable
+            style={styles.noteButton}
+            onPress={(e) => {
+              e.stopPropagation();
+              onNotePress(item);
+            }}
+            accessibilityLabel="メモを見る"
+          >
+            <Ionicons
+              name="document-text-outline"
+              size={20}
+              color={colors.accent.primary}
+            />
+          </Pressable>
+        )}
 
         {onItemDelete && (
           <Pressable
@@ -294,5 +313,9 @@ const styles = StyleSheet.create({
   fullImage: {
     width: '100%',
     height: '100%',
+  },
+  noteButton: {
+    padding: 8,
+    marginRight: 0,
   },
 });

--- a/src/components/GroupedPicklistItems.tsx
+++ b/src/components/GroupedPicklistItems.tsx
@@ -125,6 +125,9 @@ export const GroupedPicklistItems: React.FC<GroupedPicklistItemsProps> = ({
               style={[styles.itemQuantity, { color: colors.text.secondary }]}
             >
               {item.quantity} {item.unit || '個'}
+              {typeof item.maxPrice === 'number' && !isNaN(item.maxPrice)
+                ? ` / 価格上限: ${item.maxPrice}円`
+                : ''}
             </Text>
           </View>
 

--- a/src/components/GroupedPicklistItems.tsx
+++ b/src/components/GroupedPicklistItems.tsx
@@ -125,8 +125,10 @@ export const GroupedPicklistItems: React.FC<GroupedPicklistItemsProps> = ({
               style={[styles.itemQuantity, { color: colors.text.secondary }]}
             >
               {item.quantity} {item.unit || '個'}
-              {typeof item.maxPrice === 'number' && !isNaN(item.maxPrice)
-                ? ` / 価格上限: ${item.maxPrice}円`
+              {typeof item.maxPrice === 'number' &&
+              !isNaN(item.maxPrice) &&
+              item.maxPrice > 0
+                ? ` / 価格上限: ${item.maxPrice.toLocaleString()}円`
                 : ''}
             </Text>
           </View>

--- a/src/stores/useFrequentProductStore.ts
+++ b/src/stores/useFrequentProductStore.ts
@@ -128,13 +128,6 @@ export const useFrequentProductStore = create<FrequentProductState>()(
             store.initializeDefaultProducts();
           }, 0);
         }
-        if (__DEV__) {
-          console.log(
-            'State hydrated:',
-            state?.products.length ?? 0,
-            'products'
-          );
-        }
       },
       partialize: (state) => {
         // エラーを防ぐために永続化する前に状態を検証


### PR DESCRIPTION
主な変更点・改善内容
リスト詳細画面で「個数」の右側に「価格上限」を表示
リスト詳細画面の一番下の行と「よく買う商品から追加」ボタンの重なりを解消（リスト下部に余白を追加）
「よく買う商品から追加」ボタンの下部余白を調整し、より下に配置
モーダルピッカーのオーバーレイ部分タップで閉じられるよう改善
メモ欄・価格上限欄の情報がリスト詳細画面でも正しく表示されるよう修正
その他UI/UXの細かな改善

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - リストアイテムのメモ表示機能を追加。アイテムにメモがある場合、アイコンボタンから内容をモーダルで確認可能になりました。
  - アイテムの数量表示に最大価格（設定されている場合）を追加。

- **改善**
  - ピッカーモーダルの操作性を向上。モーダル外のタップで閉じることができるようになりました。
  - リスト画面下部のボタン位置を微調整しました。

- **その他**
  - デバッグ用ログ出力を削除しました。
  - バージョン番号を1.0.1に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->