### PR TITLE
個別リストに戻るボタンを追加 #65

### DIFF
--- a/app/(products)/add-to-list.tsx
+++ b/app/(products)/add-to-list.tsx
@@ -77,7 +77,7 @@ export default function AddToListScreen() {
         priority: 2, // デフォルトで中優先度を設定
       }))
     );
-    router.push(`/(tabs)/list/${selectedList}`);
+    router.replace(`/(tabs)/list/${selectedList}`);
   };
 
   return (

--- a/app/(tabs)/list/[id].tsx
+++ b/app/(tabs)/list/[id].tsx
@@ -160,6 +160,17 @@ export default function ListDetailScreen() {
           ]}
         >
           <View style={styles.headerContent}>
+            <Pressable
+              style={styles.backButton}
+              onPress={() => router.push('/')}
+              accessibilityLabel="買い物リスト一覧に戻る"
+            >
+              <Ionicons
+                name="chevron-back"
+                size={24}
+                color={colors.accent.primary}
+              />
+            </Pressable>
             {editMode ? (
               <View style={styles.editNameContainer}>
                 <TextInput
@@ -742,5 +753,9 @@ const styles = StyleSheet.create({
   },
   listContent: {
     flex: 1,
+  },
+  backButton: {
+    padding: 8,
+    marginRight: 8,
   },
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "picklist",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "main": "expo-router/entry",
   "scripts": {
     "start": "npx expo start -c",
@@ -10,7 +10,8 @@
     "lint": "eslint \"**/*.{js,jsx,ts,tsx}\"",
     "typescript": "tsc --noEmit",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "build:ios": "eas build --platform ios"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.0.4",


### PR DESCRIPTION
- リスト詳細画面のヘッダー左に「一覧に戻る」ボタンを追加
  - → 一覧画面（トップ）にすぐ戻れるように

- 戻るボタンのスタイルをStyleSheetで管理し、保守性・パフォーマンス向上
- リストに追加後、個別リスト画面に遷移した際に履歴をリセット
  - → 戻るボタンで「add-to-list」や「よく買う商品」画面に戻らない直感的な動作

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - リスト詳細画面のヘッダーに「戻る」ボタンを追加しました。これにより、ショッピングリスト一覧画面に簡単に戻ることができます。アクセシビリティラベルも追加されています。

- **改善**
  - 商品追加後の画面遷移方法を変更し、履歴スタックに新しいページを追加せずにリスト画面へ移動するようになりました。

- **その他**
  - iOS向けビルド用のnpmスクリプトを追加しました。
  - パッケージバージョンを1.0.2に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->