### PR TITLE
feat: エラー表示機能を実装 #10

### DIFF
--- a/app/(products)/add.tsx
+++ b/app/(products)/add.tsx
@@ -16,6 +16,7 @@ import * as Crypto from 'expo-crypto';
 import { Ionicons } from '@expo/vector-icons';
 import { Menu } from 'react-native-paper';
 import { useThemeContext } from '../../src/components/ThemeProvider';
+import { ErrorDisplay } from '../../src/components/ErrorDisplay';
 
 export default function AddProductScreen() {
   const { colors } = useThemeContext();
@@ -37,6 +38,7 @@ export default function AddProductScreen() {
   const [menuVisible, setMenuVisible] = useState(false);
   const [isNewCategory, setIsNewCategory] = useState(false);
   const [newCategoryName, setNewCategoryName] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
 
   // カテゴリーを優先順位でソート
   const sortedCategories = useMemo(() => {
@@ -45,9 +47,12 @@ export default function AddProductScreen() {
 
   const handleSubmit = () => {
     if (!productData.name.trim()) {
-      // TODO: エラー表示の実装
+      setErrorMessage('商品名を入力してください');
       return;
     }
+
+    // エラーメッセージをクリア
+    setErrorMessage('');
 
     // 新しいカテゴリーを作成
     let categoryId = productData.category;
@@ -138,18 +143,20 @@ export default function AddProductScreen() {
               style={[
                 styles.input,
                 {
-                  borderColor: colors.border.primary,
+                  borderColor: errorMessage ? colors.state.error : colors.border.primary,
                   backgroundColor: colors.background.primary,
                   color: colors.text.primary,
                 },
               ]}
               value={productData.name}
-              onChangeText={(text) =>
-                setProductData((prev) => ({ ...prev, name: text }))
-              }
+              onChangeText={(text) => {
+                setProductData((prev) => ({ ...prev, name: text }));
+                if (errorMessage) setErrorMessage('');
+              }}
               placeholder="商品名を入力"
               placeholderTextColor={colors.text.tertiary}
             />
+            <ErrorDisplay message={errorMessage} visible={!!errorMessage} />
           </View>
 
           <View style={styles.formGroup}>

--- a/app/(products)/edit.tsx
+++ b/app/(products)/edit.tsx
@@ -16,6 +16,7 @@ import { CustomImagePicker } from '../../src/components/ImagePicker';
 import { Ionicons } from '@expo/vector-icons';
 import { Menu } from 'react-native-paper';
 import { useThemeContext } from '../../src/components/ThemeProvider';
+import { ErrorDisplay } from '../../src/components/ErrorDisplay';
 
 export default function EditProductScreen() {
   const { colors } = useThemeContext();
@@ -32,6 +33,7 @@ export default function EditProductScreen() {
   const [menuVisible, setMenuVisible] = useState(false);
   const [isNewCategory, setIsNewCategory] = useState(false);
   const [newCategoryName, setNewCategoryName] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
 
   // カテゴリーを優先順位でソート
   const sortedCategories = useMemo(() => {
@@ -67,9 +69,12 @@ export default function EditProductScreen() {
 
   const handleSubmit = () => {
     if (!productData.name.trim()) {
-      // TODO: エラー表示の実装
+      setErrorMessage('商品名を入力してください');
       return;
     }
+
+    // エラーメッセージをクリア
+    setErrorMessage('');
 
     // 新しいカテゴリーを作成
     let categoryId = productData.category;
@@ -184,18 +189,20 @@ export default function EditProductScreen() {
               style={[
                 styles.input,
                 {
-                  borderColor: colors.border.primary,
+                  borderColor: errorMessage ? colors.state.error : colors.border.primary,
                   backgroundColor: colors.background.primary,
                   color: colors.text.primary,
                 },
               ]}
               value={productData.name}
-              onChangeText={(text) =>
-                setProductData({ ...productData, name: text })
-              }
+              onChangeText={(text) => {
+                setProductData({ ...productData, name: text });
+                if (errorMessage) setErrorMessage('');
+              }}
               placeholder="商品名を入力"
               placeholderTextColor={colors.text.tertiary}
             />
+            <ErrorDisplay message={errorMessage} visible={!!errorMessage} />
           </View>
 
           <View style={styles.inputGroup}>

--- a/src/components/ErrorDisplay.tsx
+++ b/src/components/ErrorDisplay.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useThemeContext } from './ThemeProvider';
+
+interface ErrorDisplayProps {
+  message: string;
+  visible: boolean;
+  type?: 'error' | 'warning' | 'info';
+}
+
+export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({
+  message,
+  visible,
+  type = 'error',
+}) => {
+  const { colors } = useThemeContext();
+
+  if (!visible) return null;
+
+  const getIconName = () => {
+    switch (type) {
+      case 'error':
+        return 'alert-circle';
+      case 'warning':
+        return 'warning';
+      case 'info':
+        return 'information-circle';
+      default:
+        return 'alert-circle';
+    }
+  };
+
+  const getColor = () => {
+    switch (type) {
+      case 'error':
+        return colors.state.error;
+      case 'warning':
+        return '#FF9500';
+      case 'info':
+        return colors.accent.primary;
+      default:
+        return colors.state.error;
+    }
+  };
+
+  return (
+    <View style={[styles.container, { backgroundColor: getColor() + '15' }]}>
+      <Ionicons name={getIconName()} size={20} color={getColor()} />
+      <Text style={[styles.message, { color: getColor() }]}>{message}</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 12,
+    borderRadius: 8,
+    marginVertical: 8,
+    gap: 8,
+  },
+  message: {
+    flex: 1,
+    fontSize: 14,
+    fontWeight: '500',
+  },
+});


### PR DESCRIPTION
## Summary
商品追加・編集画面でのエラー表示機能を実装しました。

## 実装内容
- **ErrorDisplayコンポーネント**を新規作成
  - error, warning, info タイプに対応
  - テーマ対応
  - アイコン付きのエラー表示

- **商品追加画面（add.tsx）**でのエラー表示
  - 商品名が空の場合のバリデーション
  - エラー時の入力フィールドのボーダー色変更
  - 入力時の自動エラークリア

- **商品編集画面（edit.tsx）**でのエラー表示
  - 同様のバリデーション機能を追加

## 修正されたTODO
- `app/(products)/add.tsx:48` の TODO コメント
- `app/(products)/edit.tsx:70` の TODO コメント

## Test plan
- [ ] 商品名を空にして保存ボタンを押すとエラーが表示される
- [ ] エラー表示後に商品名を入力するとエラーが消える  
- [ ] エラー時に入力フィールドのボーダーが赤くなる
- [ ] ライト/ダークモードでの表示確認

Closes #10

🤖 Generated with [Claude Code](https://claude.ai/code)