### PR TITLE
feat: カレンダーを月単位表示に変更

### DIFF
--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -79,16 +79,15 @@ export const Calendar: React.FC<CalendarProps> = ({
       if (minDate && current < minDate) isDisabled = true;
       if (maxDate && current > maxDate) isDisabled = true;
 
-      if (!isDisabled) {
-        days.push({
-          date: dateStr,
-          day: current.getDate(),
-          isCurrentMonth,
-          isToday,
-          isSelected,
-          hasHistory,
-        });
-      }
+      // 常に日付情報を追加（空のセルも含む）
+      days.push({
+        date: dateStr,
+        day: current.getDate(),
+        isCurrentMonth,
+        isToday,
+        isSelected,
+        hasHistory,
+      });
 
       current.setDate(current.getDate() + 1);
     }
@@ -190,39 +189,40 @@ export const Calendar: React.FC<CalendarProps> = ({
               onPress={() => handleDatePress(dayInfo)}
               disabled={!dayInfo.isCurrentMonth}
             >
-              <Text
-                style={[
-                  styles.dayText,
-                  { color: colors.text.primary },
-                  !dayInfo.isCurrentMonth && {
-                    color: colors.text.tertiary,
-                  },
-                  dayInfo.isSelected && {
-                    color: colors.text.inverse,
-                    fontWeight: '600',
-                  },
-                  dayInfo.isToday && !dayInfo.isSelected && {
-                    color: colors.accent.primary,
-                    fontWeight: '600',
-                  },
-                ]}
-              >
-                {dayInfo.day}
-              </Text>
+              {dayInfo.isCurrentMonth ? (
+                <>
+                  <Text
+                    style={[
+                      styles.dayText,
+                      { color: colors.text.primary },
+                      dayInfo.isSelected && {
+                        color: colors.text.inverse,
+                        fontWeight: '600',
+                      },
+                      dayInfo.isToday && !dayInfo.isSelected && {
+                        color: colors.accent.primary,
+                        fontWeight: '600',
+                      },
+                    ]}
+                  >
+                    {dayInfo.day}
+                  </Text>
               
-              {/* 履歴がある日付のマーク */}
-              {dayInfo.hasHistory && (
-                <View
-                  style={[
-                    styles.historyDot,
-                    {
-                      backgroundColor: dayInfo.isSelected
-                        ? colors.text.inverse
-                        : colors.accent.primary,
-                    },
-                  ]}
-                />
-              )}
+                  {/* 履歴がある日付のマーク */}
+                  {dayInfo.hasHistory && (
+                    <View
+                      style={[
+                        styles.historyDot,
+                        {
+                          backgroundColor: dayInfo.isSelected
+                            ? colors.text.inverse
+                            : colors.accent.primary,
+                        },
+                      ]}
+                    />
+                  )}
+                </>
+              ) : null}
             </Pressable>
           ))}
         </View>
@@ -312,6 +312,7 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     marginVertical: 2,
     position: 'relative',
+    minHeight: 40,
   },
   dayText: {
     fontSize: 16,


### PR DESCRIPTION
## Summary
- カレンダーコンポーネントを月単位で表示するように改善
- 当月の日付のみを表示し、前月・翌月の日付は空白として表示

## Changes
- 当月以外の日付を非表示に（空のセルとして表示）
- 月の切り替えナビゲーション機能はそのまま維持
- 履歴マーカーも当月の日付のみに表示
- カレンダーのグリッドレイアウトは維持

## Screenshots
- 前月・翌月の日付が表示されなくなり、よりすっきりとした月カレンダー表示になります
- 日曜日から土曜日までの週構造は維持されます
- 月初が週の途中から始まる場合は、前の日付は空白で表示されます

## Test plan
- [ ] カレンダーが月単位で正しく表示されることを確認
- [ ] 前月・翌月の日付が空白として表示されることを確認
- [ ] 月の切り替えが正しく動作することを確認
- [ ] 履歴マーカーが当月の日付のみに表示されることを確認
- [ ] 日付選択が正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)